### PR TITLE
Add possibility to test Debian packages building.

### DIFF
--- a/debian.py
+++ b/debian.py
@@ -1,0 +1,126 @@
+"""
+Debian-related components for metabuildbot.
+"""
+buildbot_git_repo = 'git://github.com/buildbot/buildbot.git'
+debian_buildbot_git_repo = 'git://github.com/buildbot/debian-buildbot.git'
+debian_buildbot_slave_git_repo = 'git://github.com/buildbot/debian-buildbot-slave.git'
+
+from buildbot.scheduler import Scheduler
+from buildbot.schedulers.triggerable import Triggerable
+
+masterTarballScheduler = Scheduler(name="tarball-master", branch="master",
+                                 treeStableTimer=None,
+                                 properties={"component":"master"},
+                                 builderNames=["tarball-master"])
+masterDebScheduler = Triggerable(name="deb-master",
+                                 properties={"debian-repo":debian_buildbot_git_repo},
+                                 builderNames=["deb-master"])
+slaveTarballScheduler = Scheduler(name="tarball-slave", branch="master",
+                                 treeStableTimer=None,
+                                 properties={"component":"slave"},
+                                 builderNames=["tarball-slave"])
+slaveDebScheduler = Triggerable(name="deb-slave",
+                                 properties={"debian-repo":debian_buildbot_slave_git_repo},
+                                 builderNames=["deb-slave"])
+
+schedulers = [
+        masterTarballScheduler,
+        masterDebScheduler,
+        slaveTarballScheduler,
+        slaveDebScheduler
+        ]
+
+from buildbot.process.factory import BuildFactory
+from buildbot.steps.source import Git
+from buildbot.steps.shell import ShellCommand
+from buildbot.steps.shell import SetProperty
+from buildbot.process.properties import WithProperties, Property
+from buildbot.steps.trigger import Trigger
+
+from buildbot.steps.transfer import FileDownload, FileUpload
+
+relative_dist_dir = "%(component)s/dist"
+remove_old_tarballs = ShellCommand(command=["find", ".", "-delete"],
+        workdir=WithProperties("build/" + relative_dist_dir))
+
+buildbot_checkout = Git(repourl=buildbot_git_repo)
+create_tarball = ShellCommand(command=["python", "setup.py", "sdist"],
+        workdir=WithProperties("build/%(component)s"))
+
+def tarball_property(rc, stdout, stderr):
+    import re
+    version_re = re.compile(r'buildbot(-slave)?-(.*)\.(tar|zip).*')
+    tarballs = [x.strip() for x in stdout.split()]
+    versions = [version_re.match(x).group(2) for x in tarballs]
+    return { "tarball":tarballs[0], "tarball_version":versions[0] }
+
+mk_tarball_property = SetProperty(command=["ls", "--color=never" ,
+        WithProperties(relative_dist_dir)],
+        extract_fn=tarball_property)
+
+upload_tarball = FileUpload(
+        slavesrc=WithProperties(relative_dist_dir + "/%(tarball)s"),
+        masterdest=WithProperties("public_html/%(component)s/%(tarball)s"))
+
+trigger_deb_build = Trigger(schedulerNames=[WithProperties("deb-%(component)s")],
+    waitForFinish=False,
+    alwaysUseLatest=True,
+    set_properties={ 'branch' : ["master", "upstream"] },
+    copy_properties=[ 'tarball', 'tarball_version', 'component' ])
+
+tarball_factory = BuildFactory([
+    remove_old_tarballs,
+    buildbot_checkout,
+    create_tarball,
+    mk_tarball_property,
+    upload_tarball,
+    trigger_deb_build
+    ])
+
+rm_rf = ShellCommand(command=["find", ".", "-delete"], workdir=Property('workdir'))
+debian_checkout = ShellCommand(command=["git", "clone",
+    Property("debian-repo"), "-b" "unreleased", "."])
+fetch_upstream_branch = ShellCommand(
+        command=["git", "branch", "upstream", "origin/upstream"], 
+        warnOnFailure=True)
+download_tarball = FileDownload(
+        mastersrc=WithProperties("public_html/%(component)s/%(tarball)s"),
+        slavedest=WithProperties("%(workdir)s/%(tarball)s"))
+import_orig = ShellCommand(
+        command=["git-import-orig",
+    WithProperties("--upstream-version=%(tarball_version)s"),
+    WithProperties("%(workdir)s/%(tarball)s")])
+update_changelog = ShellCommand(
+        command=["git-dch", "--auto", "--snapshot"], 
+        env={"EDITOR":"/bin/true"})
+build_deb_package = ShellCommand(command=["git-buildpackage", "--git-ignore-new", "-us", "-uc"])
+
+deb_factory = BuildFactory([
+    rm_rf,
+    debian_checkout,
+    fetch_upstream_branch,
+    download_tarball,
+    import_orig,
+    update_changelog,
+    build_deb_package
+    ])
+
+from buildbot.config import BuilderConfig
+
+builders = []
+builders.append(
+    BuilderConfig(name="tarball-master", 
+        slavenames=["metaslave"],
+        factory=tarball_factory))
+builders.append(
+    BuilderConfig(name="tarball-slave", 
+        slavenames=["metaslave"],
+        factory=tarball_factory))
+builders.append(
+    BuilderConfig(name="deb-master", 
+        slavenames=["metaslave"],
+        factory=deb_factory))
+builders.append(
+    BuilderConfig(name="deb-slave", 
+        slavenames=["metaslave"],
+        factory=deb_factory))

--- a/master.cfg
+++ b/master.cfg
@@ -18,6 +18,8 @@ c = BuildmasterConfig = {}
 c['slaves'] = slaves
 c['schedulers'] = schedulers
 c['builders'] = builders
+from metabbotcfg.debian import builders as deb_builders
+c['builders'] += deb_builders
 c['status'] = status
 c['slavePortnum'] = 9989
 c['projectName'] = "Buildbot"

--- a/schedulers.py
+++ b/schedulers.py
@@ -8,6 +8,8 @@ from buildbot.schedulers.trysched import Try_Userpass
 from metabbotcfg.slaves import slaves
 from metabbotcfg import builders
 
+from metabbotcfg.debian import schedulers as deb_schedulers
+
 schedulers.append(Scheduler(name="all", branch='master',
                                  treeStableTimer=10,
                                  builderNames=[ b['name'] for b in builders.builders ]))
@@ -17,3 +19,5 @@ schedulers.append(ForceScheduler(name="force",
     project=FixedParameter(name="project", default=""),
     properties=[],
     builderNames=[ b['name'] for b in builders.builders ]))
+
+schedulers += deb_schedulers

--- a/slaves.py
+++ b/slaves.py
@@ -157,6 +157,7 @@ slaves = [
 #        keypair_name='buildbot-setup',
 #        security_name='buildslaves',
 #        ),
+    MySlave("debian", run_single=False, run_config=False, max_builds=4)
 ]
 
 # these are slaves that haven't been up and from whose owners I have not heard in a while


### PR DESCRIPTION
Hi, here's a first patch to get metabuildbot create Debian packages. This patch adds additional builders, schedulers and one slave. This patch does just building packages as someone would actually do this by hand. I'll try to unite some buildsteps into one to get more clean view of things. I also tried to minimize impact on other configuration items in metabuildbot. However I couldn't find a proper way to mix in list of builders since there's no obvious reason to invoke several builders (for which triggered schedulers are present) without sending necessary Property values.
# How does this work?

You may see everything in details on [buildbot.homeofus.org.ua](http://buildbot.homeofus.org.ua) (debian builds only) and [metabuildbot.homeofus.org.ua](http://metabuildbot.homeofus.org.ua) (exactly code as in this pull request). Building packages for Debian depends on several tools and repositories. 
## Repositories

The repositories [buildbot/debian-buildbot](https://github.com/buildbot/debian-buildbot) and [buildbot/debian-buildbot-slave](https://github.com/buildbot/debian-buildbot-slave) are based on buildbot packages' source distributions (e.g. the one you get running `python setup.py sdist`). Each repository has tags for every released upstream version and relative debian package. There is an upstream branch which holds DFSG-compliant upstream sources (e.g. imported tarball, but non-distributable content is removed). Fortunately Buildbot never had such files in its tarballs (there were some in the repo before, like CorelDraw paintings, but only in the repo). All other branches include debian-specific information like debian/ directory itself. It's common to use master here as a primary debian branch and so it is reserved for packaging buildbot to Debian itself.

To get things working in continious manner (e.g. some debian patches will break the build once the files are moved/heavily changed) and to make possibility for everyone to contribute i've created `unreleased` branch which is used by the buildslave. 

When new release is published, all changes in `unreleased` branch will be merged into master branch with everyone mentioned. Then a new bunch of tags will be created and the new iteration begins.

If there would be a need to support some debian/based distribution which will require some changes to get working(like debian-backports which does not have some tools for package building), a new branch is created and maintained.
## Tools

Build process relies mostly on git command-line and `git-buildpackage` tools. It can be used to build packages on several Debian-based distributions from one client using `pbuilder` or `cowbuilder` tools. 
# Build process

Currently this type of build will give us building results on specific distributions. Unlike other builders which use git to build project this builder uses tarballs that may indicate that some files are forgotten to be added to distribution. 

All these tarballs are transfered between builds by master and stored in public_html/(master|slave) and _not removed_ from master when build is done. This allows you to force rebuild for the builder which actually packages buildbot. But, if space is more important ( it's 4.5 Mb per revision currently) then I'll add another step to clean the tarball. It's ok while there are only two exclusive builders. If there would be several builders on each tarball, then some cron job will be more useful.

Current build steps are not fully configured (e.g. some steps _should_ stop build if failed) and don't have fancy names but hopefully this will be changed in the nearest future.
