### PR TITLE
Remove maruel's build slaves.

### DIFF
--- a/slaves.py
+++ b/slaves.py
@@ -96,20 +96,6 @@ slaves = [
         },
         ),
 
-    # maruel
-    MySlave('xp-msysgit',
-        max_builds=1,
-        os='winxp',
-        use_simple=True,
-        ),
-
-    MySlave('win7-cygwin',
-        max_builds=1,
-        run_single=False,
-        os='win7',
-        test_master=False, # master doesn't work on cygwin
-        ),
-
     # Mozilla
     MySlave('cm-bbot-linux-001',
         max_builds=3,


### PR DESCRIPTION
They have been broken for a very long time and are not maintained properly.
So at that point it's more noise than usefulness.
