### PR TITLE
disable docs generation

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -414,11 +414,11 @@ def mkbuildsfactory():
 
 #### docs, coverage, etc.
 
-builders.append({
-    'name' : 'docs',
-    'slavenames' : names(get_slaves(buildbot_net=True)),
-    'factory' : mkdocsfactory(),
-    'category' : 'docs' })
+#builders.append({
+#    'name' : 'docs',
+#    'slavenames' : names(get_slaves(buildbot_net=True)),
+#    'factory' : mkdocsfactory(),
+#    'category' : 'docs' })
 
 builders.append({
     'name' : 'coverage',


### PR DESCRIPTION
With the docs.bb.net building its own stuff, this builder can be disabled.

I just commented out it, so we can re-enable it should we have any reasons to do so.