### PR TITLE
Remove --color=none option

### DIFF
--- a/debian.py
+++ b/debian.py
@@ -73,7 +73,7 @@ def tarball_property(rc, stdout, stderr):
     }
 
 mk_tarball_property = SetPropertyFromCommand(
-    command=["ls", "--color=never", WithProperties(relative_dist_dir)],
+    command=["ls", WithProperties(relative_dist_dir)],
     extract_fn=tarball_property)
 
 upload_tarball = FileUpload(


### PR DESCRIPTION
The tarball-* builds now run on FreeBSD and its ls does not support the --color option.

This (hopefully) fixes the failing tarball-master and tarball-slave builds.