### PR TITLE
remove Python 2.5 builders

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -499,21 +499,17 @@ twisted_versions = dict(
 )
 
 python_versions = dict(
-    py25='python2.5',
     py26='python2.6',
     py27='python2.7',
 )
 
 # versions of twisted and python only supported by slave
 slave_only_twisted = ['tw0900', 'tw1020']
-slave_only_python = ['py25']
+slave_only_python = []
 
 # incompatible versions of twisted and python
 incompat_tw_py = [
     ('tw0900', 'py27'),
-    ('tw1220', 'py25'),
-    ('tw1320', 'py25'),
-    ('tw1400', 'py25'),
 ]
 
 for py, python_version in python_versions.items():

--- a/slaves.py
+++ b/slaves.py
@@ -23,7 +23,6 @@ class MySlaveBase(object):
     # specific-configuration builders.  Specific supported python versions
     # are given, too
     run_config = False
-    py25 = False
     py26 = False
     py27 = False
     pypy17 = False
@@ -96,7 +95,6 @@ slaves = [
         run_single=False,
         run_config=True,
         tw0810 = True,
-        py25=True,
         py26=True,
         py27=True,
         nodejs=True,
@@ -113,7 +111,6 @@ slaves = [
         max_builds=4,
         run_single=False,
         run_config=True,
-        py25=True, # hand-compiled in /usr/local
         py26=True,
         py27=True, # hand-compiled in /usr/local
         pyqt4=True, # installed in system python
@@ -130,7 +127,6 @@ slaves = [
         max_builds=4,
         run_single=False,
         run_config=True,
-        py25=False,
         py26=False,
         py27=True,
         ),
@@ -139,7 +135,6 @@ slaves = [
         max_builds=4,
         run_single=False,
         run_config=True,
-        py25=False,
         py26=False,
         py27=True,
         ),
@@ -157,7 +152,6 @@ slaves = [
         max_builds=2,
         run_single=False,
         run_config=True,
-        py25=True,
         py26=True,
         py27=True,
         # os x mountain lion doesn't support old twisteds, it seems


### PR DESCRIPTION
Since Python 2.5 is not supported any more, there's little reason to try to build with it.