### PR TITLE
get rid of Python 2.4 and 2.5 builders

### DIFF
--- a/slaves.py
+++ b/slaves.py
@@ -25,8 +25,6 @@ class MySlaveBase(object):
     # specific-configuration builders.  Specific supported python versions
     # are given, too
     run_config = False
-    py24 = False
-    py25 = False
     py26 = False
     py27 = False
     pypy17 = False
@@ -96,8 +94,6 @@ slaves = [
             run_single=False,
             run_config=True,
             tw0810=True,
-            py24=True,
-            py25=True,
             py26=True,
             py27=True,
             nodejs=True),
@@ -107,8 +103,6 @@ slaves = [
             max_builds=4,
             run_single=False,
             run_config=True,
-            py24=False,
-            py25=True, # hand-compiled in /usr/local
             py26=True,
             py27=True, # hand-compiled in /usr/local
             pyqt4=True, # installed in system python


### PR DESCRIPTION
* minimum requirement for both master and build slave is Python 2.6