### PR TITLE
add option to graceful shutdown a worker from the UI

### DIFF
--- a/status.py
+++ b/status.py
@@ -13,6 +13,7 @@ authz = Authz(
     auth=BasicAuth(users),
     forceBuild='auth',
     forceAllBuilds='auth',
+    gracefulShutdown='auth'
 )
 
 status.append(html.WebStatus(


### PR DESCRIPTION
when there are know workers failing, it is best to just shutdown from the UI, waiting for the owner to fix