### PR TITLE
always upgrade packages to the latest version

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -69,7 +69,7 @@ class VirtualenvSetup(ShellCommand):
         for pkg in self.virtualenv_packages:
             command.append(textwrap.dedent("""\
             echo "Installing %(pkg)s";
-            "$VE/bin/pip" install %(pkg)s || exit 1
+            "$VE/bin/pip" install -U %(pkg)s || exit 1
             """).strip() % dict(pkg=pkg))
 
         # make $VE/bin/trial work, even if we inherited trial from site-packages


### PR DESCRIPTION

Looks like old version of moto have bugs which makes it difficult to investigate on metabuildbot slaves.

It is anyway better to always take latest and greatest