### PR TITLE
nine.buildbot.net improvements

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -16,9 +16,9 @@ www.setupWWW(c)
 
 c['projectName'] = "Buildbot"
 c['projectURL'] = "http://buildbot.net/"
-c['buildbotURL'] = "https://nine.buildbot.net/"
 
 # FIXME: this is not yet implemented in nine
 c['changeHorizon'] = 200
 c['buildHorizon'] = 100
 c['logHorizon'] = 100
+c['buildbotNetUsageData'] = 'basic'

--- a/reporters.py
+++ b/reporters.py
@@ -2,11 +2,11 @@ from buildbot.plugins import reporters as reporters_plugins
 
 reporters = []
 
-reporters.append(
-    reporters_plugins.IRC(host="irc.freenode.net",
-                          nick="bb-9-meta",
-                          notify_events={
-                              'successToFailure': 1,
-                              'failureToSuccess': 1,
-                          },
-                          channels=["#buildbot"]))
+# reporters.append(
+#     reporters_plugins.IRC(host="irc.freenode.net",
+#                           nick="bb-9-meta",
+#                           notify_events={
+#                               'successToFailure': 1,
+#                               'failureToSuccess': 1,
+#                           },
+#                           channels=["#buildbot"]))

--- a/tox.ini
+++ b/tox.ini
@@ -7,17 +7,21 @@ passenv = http_proxy https_proxy
 
 [testenv:config]
 deps=
-    buildbot==0.9.0rc2
+    buildbot==0.9.0rc3
     mock
-    buildbot_pkg==0.9.0rc2
+    txrequests
+    buildbot_pkg==0.9.0rc3
 setenv=
     CHECK_CONFIG=true
     PYTHONPATH=.
 changedir=
     {envtmpdir}
-whitelist_externals=ln
+whitelist_externals=
+    ln
+    touch
 commands=
-    pip install --pre git+https://github.com/buildbot/buildbot_travis
+    pip install --pre git+https://github.com/buildbot/buildbot_travis buildbot-worker
+    touch {toxinidir}/github_token
     ln -s {toxinidir} metabbotcfg
     ln -s {toxinidir}/master.cfg master.cfg
     buildbot checkconfig

--- a/www.py
+++ b/www.py
@@ -4,8 +4,12 @@ import platform
 
 
 def setupWWW(c):
+    # if prod
     if platform.node() == 'nine':
         c['www']['port'] = 'tcp:8010:interface=192.168.80.244'
+        c['buildbotURL'] = "https://nine.buildbot.net/"
+    else:  # for testing
+        c['buildbotURL'] = "http://localhost:8010/"
     c['www']['plugins']['waterfall_view'] = {}
 
     # read the password that ansible did sent to us, and override what is in the yaml


### PR DESCRIPTION
- disable IRC as it is not yet very useful especially with travis
- enable more hyper workers
- enable local workers for testing in //
- simplify config for local testing