### PR TITLE
local workers do not require passwords

### DIFF
--- a/workers.py
+++ b/workers.py
@@ -96,7 +96,7 @@ class MyLocalWorker(MyWorkerBase, worker.LocalWorker):
         kwargs = self.extract_attrs(name, **kwargs)
         return worker.LocalWorker.__init__(
             self,
-            name, str(self.get_random_pass()),
+            name,
             **kwargs)
 
 


### PR DESCRIPTION
The second argument is the worker path, which eventually will fill your harddrive with worker working directories...