### PR TITLE
Add python3 venv for every version of Python which we install

### DIFF
--- a/docker/metaworker/Dockerfile
+++ b/docker/metaworker/Dockerfile
@@ -40,6 +40,10 @@ RUN apt-get update && \
         git \
         gconf2 \
         python-virtualenv \
+        python3.4-venv \
+        python3.5-venv \
+        python3.6-venv \
+        python3.7-venv \
         enchant \
         libenchant-dev \
         locales \


### PR DESCRIPTION
This is needed for running more of the buildbot CI with Python 3