### PR TITLE
docker: Don't install python3-virtualenv

### DIFF
--- a/docker/metaworker/Dockerfile
+++ b/docker/metaworker/Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update && \
         chromium-browser \
         git \
         gconf2 \
-        python3-virtualenv \
         python3.5-venv \
         python3.6-venv \
         python3.7-venv \


### PR DESCRIPTION
It clashes with python3.x-venv packages and results in the following
error:

ModuleNotFoundError: No module named 'virtualenv.seed.via_app_data'

I will merge this without review as buildbot.buildbot.net is currently broken.

cc @tardyp 