### PR TITLE
fix worker instanciation

### DIFF
--- a/workers.py
+++ b/workers.py
@@ -128,7 +128,7 @@ class MyKubeWorker(MyWorkerBase, worker.KubeLatentWorker):
             if size in HYPER_SIZES:
                 cpu, mem = HYPER_SIZES[size]
         # squeeze a bit more containers
-        cpu = cpu*0.7
+        cpu = int(cpu)*0.7
         return {
             "requests": {
                 "cpu": cpu,


### PR DESCRIPTION
fix error in metabuildbot:

        builtins.TypeError: can't multiply sequence by non-int of type 'float'