### PR TITLE
workers: Don't limit workers to partial CPU cores

### DIFF
--- a/workers.py
+++ b/workers.py
@@ -127,8 +127,7 @@ class MyKubeWorker(MyWorkerBase, worker.KubeLatentWorker):
             }
             if size in HYPER_SIZES:
                 cpu, mem = HYPER_SIZES[size]
-        # squeeze a bit more containers
-        cpu = int(cpu)*0.7
+        cpu = int(cpu)
         return {
             "requests": {
                 "cpu": cpu,


### PR DESCRIPTION
Our previous experience with smoke tests showed that when they are limited to 0.7 cpu the tests become less stable due to random jitter that may uncover race conditions. Since such race conditions are likely specific to tests and are hard to reproduce on local hardware, I think it makes sense to give tests a full core instead of having to endure random test failures we can't do anything about.