### PR TITLE
cfg: Add WORKER_PYTHON prop to reporter context

### DIFF
--- a/cfg.yml
+++ b/cfg.yml
@@ -12,7 +12,7 @@ projects:
     - master
     github_token: file:metabbotcfg/github_token
     name: buildbot
-    reporter_context: bb%(prop:TESTS:+/)s%(prop:TESTS)s%(prop:TESTS:+/)s%(prop:python)s%(prop:TESTS:+/tw:)s%(prop:TWISTED)s%(prop:TESTS:+/sqla:)s%(prop:SQLALCHEMY)s%(prop:TESTS:+/db:)s%(prop:BUILDBOT_TEST_DB_URL)s
+    reporter_context: bb%(prop:TESTS:+/)s%(prop:TESTS)s%(prop:TESTS:+/)s%(prop:python)s%(prop:TESTS:+/tw:)s%(prop:TWISTED)s%(prop:TESTS:+/sqla:)s%(prop:SQLALCHEMY)s%(prop:TESTS:+/db:)s%(prop:BUILDBOT_TEST_DB_URL)s%(prop:TESTS:+/wp:)s%(prop:WORKER_PYTHON)s
     repository: https://github.com/buildbot/buildbot
     shallow: 100
     retryFetch: true


### PR DESCRIPTION
We have several tests with different WORKER_PYTHON versions yet they get the same context for Github reporter and are displayed as single test.