### PR TITLE
workers: Run Kubernetes workers only on specified node pool

### DIFF
--- a/workers.py
+++ b/workers.py
@@ -100,6 +100,11 @@ class MyKubeWorker(MyWorkerBase, worker.KubeLatentWorker):
             }
         ]
 
+    def get_node_selector(self, props):
+        return {
+            "bb-pool-type": "work"
+        }
+
     def __init__(self, name, **kwargs):
         kwargs = self.extract_attrs(name, **kwargs)
 


### PR DESCRIPTION
This way test pods are not accidentally scheduled on nodes that are supposed to be used for system services only.