### PR TITLE
docker: Don't use sudo when setting up database

### DIFF
--- a/docker/metaworker/Dockerfile
+++ b/docker/metaworker/Dockerfile
@@ -72,7 +72,6 @@ RUN mkdir -p /etc/apt/keyrings \
         libwoff1 \
         python3-dev \
         python3-venv  \
-        sudo \
     \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
     && npm install -g yarn \
@@ -84,9 +83,23 @@ RUN mkdir -p /etc/apt/keyrings \
 COPY pg_hba.conf /etc/postgresql/13/main/pg_hba.conf
 COPY prepare_postgres /prepare_postgres
 COPY prepare_mysql /prepare_mysql
+
+# container runtimes such as runsc (gVisor) do not support elevating privileges via sudo (missing
+# setuid support). Therefore the permissions are adjusted to support running the database from the
+# same container user as the tests.
+
 RUN sed -i "s/data_directory = '.*'/data_directory = '\/scratch\/postgres'/g" /etc/postgresql/13/main/postgresql.conf
+RUN sed -i "s/ssl\\s*=\\s*.*/ssl = off/g" /etc/postgresql/13/main/postgresql.conf
 RUN sed -i "s/.*datadir\\s*=.*/datadir='\/scratch\/mysql'/g" /etc/mysql/mariadb.conf.d/50-server.cnf
-COPY sudoers /etc/sudoers
+RUN sed -i "s/.*user\\s*=.*/user=buildbot/g" /etc/mysql/mariadb.conf.d/50-server.cnf
+RUN mkdir -p /scratch \
+    && mkdir -p /run/mysqld \
+    && mkdir -p /run/postgresql \
+    && chown buildbot:buildbot /scratch \
+    && chown buildbot:buildbot /run/mysqld \
+    && chown buildbot:buildbot /run/postgresql \
+    && chown buildbot:buildbot /var/log/postgresql \
+    && chown buildbot:buildbot /etc/mysql/debian.cnf
 
 COPY --from=python-build /pyenv /pyenv
 ENV PATH="/pyenv/pybin:${PATH}"

--- a/docker/metaworker/prepare_mysql
+++ b/docker/metaworker/prepare_mysql
@@ -11,16 +11,9 @@ fi
 
 rm -rf $DBPATH
 mkdir -p $DBPATH
-chown mysql:mysql $DBPATH
 mysql_install_db --auth-root-authentication-method=normal
-/etc/init.d/mariadb start
+/etc/init.d/mariadb start --skip-grant-tables
 
-MAINT_PASSWORD=$(cat /etc/mysql/debian.cnf | grep password | head -n 1 | sed 's/.* //g')
-
-mysql -e "CREATE USER 'travis'@'localhost';"
-mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'localhost' WITH GRANT OPTION; FLUSH PRIVILEGES;"
-mysql -e "CREATE USER 'debian-sys-maint'@'localhost' IDENTIFIED BY '$MAINT_PASSWORD';"
-mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'debian-sys-maint'@'localhost' WITH GRANT OPTION; FLUSH PRIVILEGES;"
 mysql -e 'create database bbtest;'
 mysql -e 'create database bbtest0;'
 mysql -e 'create database bbtest1;'

--- a/docker/metaworker/prepare_postgres
+++ b/docker/metaworker/prepare_postgres
@@ -11,19 +11,18 @@ fi
 
 rm -rf $DBPATH
 mkdir -p $DBPATH
-chown postgres:postgres $DBPATH
 
-su postgres -c "/usr/lib/postgresql/13/bin/pg_ctl init -D /scratch/postgres"
-cp /etc/postgresql/13/main/pg_hba.conf /scratch/postgres/pg_hba.conf
+/usr/lib/postgresql/13/bin/pg_ctl init -D /scratch/postgres
+/etc/postgresql/13/main/pg_hba.conf /scratch/postgres/pg_hba.conf
 /etc/init.d/postgresql start
 
-su postgres -c "createuser buildbot"
-su postgres -c "psql -c 'create database bbtest WITH ENCODING UTF8 TEMPLATE template0 ;'"
-su postgres -c "psql -c 'create database bbtest0 WITH ENCODING UTF8 TEMPLATE template0 ;'"
-su postgres -c "psql -c 'create database bbtest1 WITH ENCODING UTF8 TEMPLATE template0 ;'"
-su postgres -c "psql -c 'create database bbtest2 WITH ENCODING UTF8 TEMPLATE template0 ;'"
-su postgres -c "psql -c 'create database bbtest3 WITH ENCODING UTF8 TEMPLATE template0 ;'"
-su postgres -c "psql -c 'create database bbtest4 WITH ENCODING UTF8 TEMPLATE template0 ;'"
-su postgres -c "psql -c 'create database bbtest5 WITH ENCODING UTF8 TEMPLATE template0 ;'"
-su postgres -c "psql -c 'create database bbtest6 WITH ENCODING UTF8 TEMPLATE template0 ;'"
-su postgres -c "psql -c 'create database bbtest7 WITH ENCODING UTF8 TEMPLATE template0 ;'"
+createdb buildbot
+psql -c 'create database bbtest WITH ENCODING UTF8 TEMPLATE template0 ;'
+psql -c 'create database bbtest0 WITH ENCODING UTF8 TEMPLATE template0 ;'
+psql -c 'create database bbtest1 WITH ENCODING UTF8 TEMPLATE template0 ;'
+psql -c 'create database bbtest2 WITH ENCODING UTF8 TEMPLATE template0 ;'
+psql -c 'create database bbtest3 WITH ENCODING UTF8 TEMPLATE template0 ;'
+psql -c 'create database bbtest4 WITH ENCODING UTF8 TEMPLATE template0 ;'
+psql -c 'create database bbtest5 WITH ENCODING UTF8 TEMPLATE template0 ;'
+psql -c 'create database bbtest6 WITH ENCODING UTF8 TEMPLATE template0 ;'
+psql -c 'create database bbtest7 WITH ENCODING UTF8 TEMPLATE template0 ;'

--- a/docker/metaworker/sudoers
+++ b/docker/metaworker/sudoers
@@ -1,2 +1,0 @@
-buildbot      ALL=(root) NOPASSWD: /prepare_postgres
-buildbot      ALL=(root) NOPASSWD: /prepare_mysql


### PR DESCRIPTION
This allows to use docker runtimes that don't have setuid properly implemented, such as gvisor.