### PR TITLE
docker: Remove log files created by postgresql installation

### DIFF
--- a/docker/metaworker/Dockerfile
+++ b/docker/metaworker/Dockerfile
@@ -99,6 +99,7 @@ RUN mkdir -p /scratch \
     && chown buildbot:buildbot /run/mysqld \
     && chown buildbot:buildbot /run/postgresql \
     && chown buildbot:buildbot /var/log/postgresql \
+    && rm -f /var/log/postgresql/* \
     && chown buildbot:buildbot /etc/mysql/debian.cnf
 
 COPY --from=python-build /pyenv /pyenv


### PR DESCRIPTION
These may require elevated permissions to overwrite.