### PR TITLE
Revert "docker: Install packages required for Python 2 tests to run"

### DIFF
--- a/docker/metaworker/Dockerfile
+++ b/docker/metaworker/Dockerfile
@@ -71,9 +71,6 @@ RUN mkdir -p /etc/apt/keyrings \
         libsoup2.4-1 \
         libwebpdemux2 \
         libwoff1 \
-        python2-pip-whl \
-        python2-setuptools-whl \
-        python2-wheel-whl \
         python3-dev \
         python3-venv  \
     \


### PR DESCRIPTION
This reverts commit 864e8a2a9217cf4506cbe7e71d5d999227b26c46.