### PR TITLE
workers: Use memory medium for scratch space on the workers

### DIFF
--- a/workers.py
+++ b/workers.py
@@ -84,6 +84,7 @@ class MyKubeWorker(MyWorkerBase, worker.KubeLatentWorker):
             {
                 "name": "scratch-volume",
                 "emptyDir": {
+                    "medium": "Memory",
                     "sizeLimit": "2Gi",
                 },
             }


### PR DESCRIPTION
This fixes extremely poor performance when database tests are run.