### PR TITLE
docker: install libgtk-4-1 needed by playwright

### DIFF
--- a/docker/metaworker/Dockerfile
+++ b/docker/metaworker/Dockerfile
@@ -63,6 +63,7 @@ RUN mkdir -p /etc/apt/keyrings \
         libgles2 \
         libgstreamer-gl1.0-0 \
         libgstreamer-plugins-bad1.0-0 \
+        libgtk-4-1 \
         libgudev-1.0-0 \
         libharfbuzz-icu0 \
         libhyphen0 \
@@ -110,4 +111,3 @@ ENV PATH="/pyenv/pybin:${PATH}"
 
 # Switch to regular user for security reasons
 USER buildbot
-


### PR DESCRIPTION
eg. https://buildbot.buildbot.net/#/builders/122/builds/4820/steps/8/logs/stdio

L554
```
╔══════════════════════════════════════════════════════╗
║ Host system is missing dependencies to run browsers. ║
║ Please install them with the following command:      ║
║                                                      ║
║     sudo yarn playwright install-deps                ║
║                                                      ║
║ Alternatively, use apt:                              ║
║     sudo apt-get install libgtk-4-1                  ║
║                                                      ║
║ <3 Playwright Team                                   ║
╚══════════════════════════════════════════════════════╝
```