### PR TITLE
Revert "docker: Use Debian 13 (Trixie)"

### DIFF
--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:13
+FROM debian:12
 LABEL org.opencontainers.image.authors="Buildbot Maintainers"
 
 USER root


### PR DESCRIPTION
This is not compatible with buildbot worker image we are using.

This reverts commit 80023a6eeaee5d88bc89e0a2b12a589643d1ebf1.