### PR TITLE
docker: Enable corepack for npm

### DIFF
--- a/docker/metaworker/Dockerfile
+++ b/docker/metaworker/Dockerfile
@@ -81,6 +81,8 @@ RUN mkdir -p /etc/apt/keyrings \
     \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
     && corepack enable \
+    # corepack needs to be specifically enabled for npm
+    && corepack enable npm \
     && curl -sL -o /tmp/chrome.deb https://github.com/p12tic/buildbot-test-data/raw/master/packages/google-chrome-stable_114.0.5735.198-1_amd64.deb \
     && (dpkg -i /tmp/chrome.deb || apt-get --fix-broken -y install) \
     && rm -rf /var/lib/apt/lists/* /tmp/chrome.deb


### PR DESCRIPTION
Ref: https://www.npmjs.com/package/corepack
> Note that the npm shims will not be installed unless explicitly requested, as npm is currently distributed with Node.js through other means.